### PR TITLE
Fully support OSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ If you want to access the database, run the following container:
 
     docker run -it --link postgres:postgres --rm postgres sh -c 'exec psql -h "$POSTGRES_PORT_5432_TCP_ADDR" -p "$POSTGRES_PORT_5432_TCP_PORT" -U postgres'
 
-Once you are in psql you can check that indeed our user & database has been created:
+Once you are in psql you can check that indeed our user & database have been created:
 
     # To list the users defined in our system use the following command
     \du
@@ -73,9 +73,9 @@ Once the database has been populated, we can start our Django application:
 
 ### Taiga-Front
 
-Frontend is slightly different because we don't have a production ready system, but the source. This means that before running our instance, we have to build it.
+The frontend is slightly different because we don't have a production ready system, but the source. This means that before running our instance, we have to build it.
 
-We have two options here: to ask politely to taiga to provide an already built version (\o/) or building and intermediate container that will pull the source from github, compile it and build our new image.
+We have two options here: to politely ask Taiga to provide an already built version (\o/) or to build an intermediate container that will pull the source from GitHub, compile it and build our new image.
 
 To build the frontend we have to run the taiga/frontend-build container
 
@@ -88,7 +88,7 @@ Now we have to create the static site from our django app, to do so, we execute 
 
         sudo docker run -it --rm  -v /data/taiga:/static taiga/taiga-back sh -c 'mv /taiga/static /static/'
 
-Once we have executed these two scrits, we should have the following in our host:
+Once we have executed these two scripts, we should have the following in our host:
 
         -> % ll /data/taiga/* | grep -vE "/data/taiga/^$"
         /data/taiga/dist:
@@ -119,5 +119,8 @@ Finally, we run the frontend
         docker run -d -p 80:80 taiga/front
 
 
+#### Note for OSX + boot2docker Users
+
+Since boot2docker actually runs the docker commands in a virtual machine you must omit the leading 'sudo' from those of the above commands that use it.
 
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -4,7 +4,7 @@ Docker taiga-back
 
 This Docker image uses the official Python 3 image (`FROM python:3`).
 
-The build file install all the dependencies, add the code from github and configure `Supervisor` with `wsgi`. It does not initializes the application nor the database.
+The build file installs all the dependencies, adds the code from GitHub and configures `Supervisor` with `wsgi`. It does not initialize the application or the database.
 
 If you want to initialise the app, you have to run the following command:
 
@@ -14,7 +14,7 @@ If you want to check that the database is created and everything is configured a
 
         docker run -it --link postgres:postgres --rm postgres sh -c 'exec psql -h "$POSTGRES_PORT_5432_TCP_ADDR" -p "$POSTGRES_PORT_5432_TCP_PORT" -U postgres'
 
-Once you are in psql you can check that indeed our user & database has been created:
+Once you are in psql you can check that indeed our user & database have been created:
 
     # To list the users defined in our system use the following command
     \du
@@ -32,8 +32,12 @@ The `build` process creates the static elements of the application, to collect t
         sudo docker run -it --rm  -v /data/taiga/dist:/static taiga/taiga-back sh -c 'mv /taiga/static /static/'
 
 
-Once everything is you can run the Django App with this command:
+Once everything is ready you can run the Django app with this command:
 
         docker run -d -p 8000:8000 --link postgres:postgres --link redis:redis --link rabbitmq:rabbitmq taiga/taiga-back
 
 
+Note for OSX + boot2docker Users
+--------------------------------
+
+Since boot2docker actually runs the docker commands in a virtual machine you must omit the leading 'sudo' from those of the above commands that use it.

--- a/frontend/build.sh
+++ b/frontend/build.sh
@@ -1,10 +1,14 @@
 #! /bin/bash
 
+if [[ $OSTYPE != darwin* ]]; then
+  SUDO=sudo
+fi
+
 rm -rf build
 mkdir build
 
 cp -r /data/taiga build
 
-sudo docker build -t ipedrazas/taiga-front .
+$SUDO docker build -t ipedrazas/taiga-front .
 
 rm -rf build

--- a/run-taiga.sh
+++ b/run-taiga.sh
@@ -1,5 +1,9 @@
 #! /bin/bash
 
-sudo docker start postgres
-sudo docker start taiga-back
-sudo docker start taiga-front
+if [[ $OSTYPE != darwin* ]]; then
+  SUDO=sudo
+fi
+
+$SUDO docker start postgres
+$SUDO docker start taiga-back
+$SUDO docker start taiga-front

--- a/setup.sh
+++ b/setup.sh
@@ -1,17 +1,21 @@
 #! /bin/bash
 
+if [[ $OSTYPE != darwin* ]]; then
+  SUDO=sudo
+fi
+
 sudo mkdir -p /data/postgresql
 
-sudo docker run -d --name postgres    -p 5432:5432  -v /data/postgresql:/var/lib/postgresql/data postgres
-sudo docker run -d --name taiga-back  -p 8001:8001  --link postgres:postgres ipedrazas/taiga-back
-sudo docker run -d --name taiga-front -p 80:80 -p 8000:8000 --link taiga-back:taiga-back ipedrazas/taiga-front
+$SUDO docker run -d --name postgres    -p 5432:5432  -v /data/postgresql:/var/lib/postgresql/data postgres
+$SUDO docker run -d --name taiga-back  -p 8001:8001  --link postgres:postgres ipedrazas/taiga-back
+$SUDO docker run -d --name taiga-front -p 80:80 -p 8000:8000 --link taiga-back:taiga-back ipedrazas/taiga-front
 
 
-sudo docker run -it --link postgres:postgres --rm postgres sh -c "su postgres --command 'createuser -h "'$POSTGRES_PORT_5432_TCP_ADDR'" -p "'$POSTGRES_PORT_5432_TCP_PORT'" -d -r -s taiga'"
-sudo docker run -it --link postgres:postgres --rm postgres sh -c "su postgres --command 'createdb -h "'$POSTGRES_PORT_5432_TCP_ADDR'" -p "'$POSTGRES_PORT_5432_TCP_PORT'" -O taiga taiga'";
-sudo docker run -it --rm --link postgres:postgres ipedrazas/taiga-back bash regenerate.sh
+$SUDO docker run -it --link postgres:postgres --rm postgres sh -c "su postgres --command 'createuser -h "'$POSTGRES_PORT_5432_TCP_ADDR'" -p "'$POSTGRES_PORT_5432_TCP_PORT'" -d -r -s taiga'"
+$SUDO docker run -it --link postgres:postgres --rm postgres sh -c "su postgres --command 'createdb -h "'$POSTGRES_PORT_5432_TCP_ADDR'" -p "'$POSTGRES_PORT_5432_TCP_PORT'" -O taiga taiga'";
+$SUDO docker run -it --rm --link postgres:postgres ipedrazas/taiga-back bash regenerate.sh
 
 
-sudo docker stop taiga-front
-sudo docker stop taiga-back
-sudo docker stop postgres
+$SUDO docker stop taiga-front
+$SUDO docker stop taiga-back
+$SUDO docker stop postgres


### PR DESCRIPTION
As it was, setup.sh generates a bunch of errors because docker on OSX fails when run via sudo. Thus:

Updated setup scripts and documentation to support boot2docker, the official Docker-for-OSX tool

-Only prefix commands with sudo if $OSTYPE shows we're running under darwin
-Also fix some minor typos

If you don't want the OSX functionality, but do want the typo fixes, I can separate them into their own PR of course.

Thanks for sharing your code!