### PR TITLE
Replace legacy rabbitmq/redis repos by official docker ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ Once you are in psql you can check that indeed our user & database have been cre
     docker run -d -p 5672:5672 -p 15672:15672 -v /data/rabbitmq:/data/log -v /data/rabbitmq:/data/mnesia --name rabbitmq rabbitmq
 
 ### Redis
-    # https://github.com/dockerfile/redis
+    # https://registry.hub.docker.com/_/redis/
 
-    docker run -d -p 6379:6379 -v /data/redis:/data --name redis dockerfile/redis
+    docker run -d -p 6379:6379 -v /data/redis:/data --name redis redis
 
 ### Taiga-Back
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Once you are in psql you can check that indeed our user & database have been cre
 
 ### RabbitMQ
 
-    # https://github.com/dockerfile/rabbitmq
+    # https://registry.hub.docker.com/_/rabbitmq/
 
     docker run -d -p 5672:5672 -p 15672:15672 -v /data/rabbitmq:/data/log -v /data/rabbitmq:/data/mnesia --name rabbitmq rabbitmq
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Once you are in psql you can check that indeed our user & database have been cre
 
     # https://github.com/dockerfile/rabbitmq
 
-    docker run -d -p 5672:5672 -p 15672:15672 -v /data/rabbitmq:/data/log -v /data/rabbitmq:/data/mnesia --name rabbitmq  dockerfile/rabbitmq
+    docker run -d -p 5672:5672 -p 15672:15672 -v /data/rabbitmq:/data/log -v /data/rabbitmq:/data/mnesia --name rabbitmq rabbitmq
 
 ### Redis
     # https://github.com/dockerfile/redis


### PR DESCRIPTION
The old ones were not working anymore (not referenced anymore in the hub)