### PR TITLE
Remove rest_framework from docker-settings.py

### DIFF
--- a/backend/docker-settings.py
+++ b/backend/docker-settings.py
@@ -206,7 +206,6 @@ INSTALLED_APPS = [
     "taiga.mdrender",
     "taiga.export_import",
 
-    "rest_framework",
     "djmail",
     "django_jinja",
     "easy_thumbnails",


### PR DESCRIPTION
According to https://github.com/taigaio/taiga-back/blob/master/requirements.txt#L2 djangorestframework is not necessary since Taiga 1.7.
This makes an import error on STEP 17 of DockerFile:

Step 17 : RUN (cd /taiga && python manage.py collectstatic --noinput)
 ---> Running in d7d6ba066a32
Trying import local.py settings...
Traceback (most recent call last):
  File "manage.py", line 10, in <module>
    execute_from_command_line(sys.argv)
  File "/usr/local/lib/python3.4/site-packages/django/core/management/__init__.py", line 385, in execute_from_command_line
    utility.execute()
  File "/usr/local/lib/python3.4/site-packages/django/core/management/__init__.py", line 354, in execute
    django.setup()
  File "/usr/local/lib/python3.4/site-packages/django/__init__.py", line 21, in setup
    apps.populate(settings.INSTALLED_APPS)
  File "/usr/local/lib/python3.4/site-packages/django/apps/registry.py", line 85, in populate
    app_config = AppConfig.create(entry)
  File "/usr/local/lib/python3.4/site-packages/django/apps/config.py", line 87, in create
    module = import_module(entry)
  File "/usr/local/lib/python3.4/importlib/__init__.py", line 109, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 2254, in _gcd_import
  File "<frozen importlib._bootstrap>", line 2237, in _find_and_load
  File "<frozen importlib._bootstrap>", line 2224, in _find_and_load_unlocked
ImportError: No module named 'rest_framework'