### PR TITLE
Update to latest stable Taiga as of 2016-04-25 13:14 CDT

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -9,7 +9,7 @@
 FROM nginx
 
 COPY taiga-front-dist/dist /taiga
-COPY conf.json /taiga/js/conf.json
+COPY conf.json /taiga/conf.json
 COPY run.sh /taiga/run.sh
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY taiga.conf /etc/nginx/conf.d/default.conf

--- a/frontend/conf.json
+++ b/frontend/conf.json
@@ -1,9 +1,13 @@
 {
     "api": "http://API_SERVER:8000/api/v1/",
     "eventsUrl": null,
+    "eventsMaxMissedHeartbeats": 5,
+    "eventsHeartbeatIntervalTime": 60000,
     "debug": true,
     "debugInfo": false,
     "defaultLanguage": "en",
+    "themes": ["taiga"],
+    "defaultTheme": "taiga",
     "publicRegisterEnabled": true,
     "feedbackEnabled": true,
     "privacyPolicyUrl": null,

--- a/frontend/run.sh
+++ b/frontend/run.sh
@@ -1,5 +1,5 @@
 #! /usr/bin/env bash
 
-sed -i "s/API_SERVER/$API_NAME/g" /taiga/js/conf.json
+sed -i "s/API_SERVER/$API_NAME/g" /taiga/conf.json
 
 nginx -g "daemon off;"

--- a/setup.sh
+++ b/setup.sh
@@ -4,10 +4,12 @@ if [[ -z "$API_NAME" ]]; then
     API_NAME="localhost";
 fi
 
+echo API_NAME: $API_NAME
+
 mkdir -p /data/postgres
 
-docker pull ipedrazas/taiga-back
-docker pull ipedrazas/taiga-front
+#docker pull ipedrazas/taiga-back
+#docker pull ipedrazas/taiga-front
 
 
 docker run -d --name postgres  -v /data/postgres:/var/lib/postgresql/data postgres


### PR DESCRIPTION
A number of changes have happended since this was last functional.

Django removed the alias for logging.NullHandler
The database backends are new:
  `django.db.backends.postgresql_psycopg2` needs to be `transaction_hooks.backends.postgresql_psycopg2`
And the location of the conf.json is now in the root of the Angular project.

These are the main changes that affected functionality for me, but I also imported the new default settings/local.py and so I don't know if it fixed other problems other than the above.

This worked for me to run setup.sh with API_NAME on a docker host.  I have a complete working taiga with sample data.  The one change you may not want is that I removed the pull command for ipedrazas/taiga-back and ipedrazas/taiga-front because they are outdated.  I built them using the build scripts in each the frontend and backend directores.

If you are going to update the docker hub hosted images, then you may want these added back in, but until then, I'm leaving them commented out.  I prefer to build them from scratch anyhow and that may solve some of the issues of this getting stale.  Maybe even replace the pull commands with build commands (cd backend; build.sh; cd ..; cd frontend; build.sh; cd ..)?

This will close #18 for freshly built containers, and if you rebuild the containers, it will close #18 for people who docker pull ipedrazas/taiga-back.

Thanks for all the work you put into this.