### PR TITLE
adjust DBs.ENGINE with required database backend

### DIFF
--- a/backend/docker-settings.py
+++ b/backend/docker-settings.py
@@ -30,7 +30,7 @@ DEBUG = False
 
 DATABASES = {
     "default": {
-        "ENGINE": "django.db.backends.postgresql",
+        "ENGINE": "transaction_hooks.backends.postgresql",
         "NAME": "taiga",
         "HOST": "postgres",
         "USER": "taiga",


### PR DESCRIPTION
There is a closed issue about that in https://github.com/taigaio/taiga-back/commit/d98455744943f88717f116bd1c1331bef63cc802 main repository.

It fixes the following error when try to create a new user story:
'DatabaseWrapper' object has no attribute 'on_commit'