### PR TITLE
Uncomment Dockerfile lines needed for shared volumes on taiga-back

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -16,8 +16,8 @@ WORKDIR /usr/src/app/taiga-back
 
 EXPOSE 8000
 
-## Volume definition in docker-compose.yml instead of here
-# VOLUME ["/taiga/static","/taiga/media"]
+# Volume definition in docker-compose.yml instead of here, soon
+VOLUME ["/taiga/static","/taiga/media"]
 
 
 RUN locale -a


### PR DESCRIPTION
These lines were commented, but they are still needed until the docker-compose method is fully implemented.