### PR TITLE
Correct `taiga-front` env variable updated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ backend/requirements.txt
 frontend/taiga-front-dist
 postgresql
 
+.idea

--- a/backend/script/set-host.sh
+++ b/backend/script/set-host.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+ESCAPED_BASE_URL="${BASE_PROTOCOL}:\/\/${BASE_DOMAIN}"
+
+MEDIA_URL=http://localhost:8000/media/
+STATIC_URL=http://localhost:8000/static/
+
+sed -i "s#$MEDIA_URL#$ESCAPED_BASE_URL/media/#g" /usr/src/app/taiga-back/settings/common.py
+sed -i "s#$STATIC_URL#$ESCAPED_BASE_URL/static/#g" /usr/src/app/taiga-back/settings/common.py
+
+python /usr/src/app/taiga-back/manage.py runserver 0.0.0.0:8000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,4 +18,5 @@ taigafront:
     ports:
         - "8080:80"
     environment:
-        - "BASE_URL=http://localhost:8000"
+        - "BASE_PROTOCOL=http"
+        - "BASE_DOMAIN=ip-address:8000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,13 @@
 postgres:
-    image: postgres
+    image: postgres:9.5.9
+    container_name: taiga_postgres
     environment:
         - "POSTGRES_USER=taiga"
         - "POSTGRES_DB=taiga"
+    ports:
+      - 5432:5432
+    volumes:
+      - /mnt/data/taiga/data:/var/lib/postgresql/data
 
 taigaback:
     image: dougg/taiga-back
@@ -10,13 +15,24 @@ taigaback:
         - postgres:postgres
     ports:
         - "8000:8000"
+    environment:
+        - "EMAIL_USE_TLS=True"
+        - "EMAIL_HOST=smtp.server.com"
+        - "EMAIL_PORT=587"
+        - "EMAIL_HOST_USER=user@email.com"
+        - "EMAIL_HOST_PASSWORD=pass"
+        - "BASE_PROTOCOL=http"
+        - "BASE_DOMAIN=ip-addresss:8000"
+    volumes:
+        - ${PWD}/backend/script/set-host.sh:/usr/src/app/taiga-back/scripts/set-host.sh
+    command: sh /usr/src/app/taiga-back/scripts/set-host.sh
 
 taigafront:
     image: dougg/taiga-front
     links:
         - taigaback:taiga-back
     ports:
-        - "8080:80"
+        - "80:80"
     environment:
         - "BASE_PROTOCOL=http"
         - "BASE_DOMAIN=ip-address:8000"


### PR DESCRIPTION
docker-compose.yml file contains env variable `BASE_URL` which is no use , because in the `run.sh` protocol and domain variable was used.
```
ESCAPED_BASE_URL="${BASE_PROTOCOL}:\/\/${BASE_DOMAIN}"
sed -i "s/BASE_URL/$ESCAPED_BASE_URL/g" /taiga/conf.json

```
So Correction would be 
```
taigafront:
    image: dougg/taiga-front
    links:
        - taigaback:taiga-back
    ports:
        - "8080:80"
    environment:
        - "BASE_PROTOCOL=http"
        - "BASE_DOMAIN=ip-adress:8000"
```
Without it taiga front fails to communicate with back-end. 

